### PR TITLE
Fixed the "Run the game"-section of the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ Used Libraries
 
 Run the game
 --------
+After pulling the repository, you can run the game using the following commands:
 - apt-get install python-pygame python-pip 
 - pip install pytmx pyscroll
+- cd src
+- python game.py
 
-run src/game.py 
+As the game was mainly developed on Debian-like systems, those commands assume Python and apt-get to be available. If you run the game on non-Debian Operating Systems, you won't be able to run the first command. Thus, you will need to install [PyGame](https://pygame.org/download.shtml) (used engine) and [pip](https://pypi.python.org/pypi/pip/) (installer for the pytmx and pyscroll) from other sources.
 
 ![screenshot](doc/source/screenshot3.png)
 


### PR DESCRIPTION
The previous version of the README led to the misconception that it is possible to run the game from any other directory than src. This version clarifies that. I furthermore clarifies that this guide is mainly Debian-centered. Fixes #5 … or maybe not since we still don't mention that we need pyscrolls <= 2.15
