### PR TITLE
Specify needed version of pyscroll, see #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Run the game
 --------
 After pulling the repository, you can run the game using the following commands:
 - apt-get install python-pygame python-pip 
-- pip install pytmx pyscroll
+- pip install pytmx 'pyscroll<2.16.2' --force-reinstall
 - cd src
 - python game.py
 


### PR DESCRIPTION
As @Algorithmus has pointed out, the game doesn't run with newer versions of pyscroll anymore. As a quick fix, we just specify the needed version.  Ultimately, we should figure out why this incompatibility happens as adjust the code to the newer version of pyscroll.
